### PR TITLE
Use the node specific hostname for jms.jndiProviderUrl

### DIFF
--- a/chipsconfig/jms.properties.template
+++ b/chipsconfig/jms.properties.template
@@ -2,7 +2,7 @@
 # JMS Settings
 #
 jms.jndiContextFactory=${JMS_JNDICONTEXTFACTORY}
-jms.jndiProviderUrl=${JMS_JNDIPROVIDERURL}
+jms.jndiProviderUrl=t3://${HOSTNAME}:7001
 jms.queueConnectionFactoryName=${JMS_QUEUECONNECTIONFACTORYNAME}
 jms.staffwareQueue=${JMS_STAFFWAREQUEUE}
 jms.cedarQueue=${JMS_CEDARQUEUE}


### PR DESCRIPTION
This allows the correct host to be used on each individual WebLogic node, and resolves an issue where the wlserver2,3 &4 nodes fail to work correctly due to the existing use of a single jms.jndiProviderUrl value for all nodes.