### PR TITLE
Bump chips-domain version 1.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.4
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.6
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This brings in a fix for accounts rendering and a new EfilingResponseJMSWorkMangager created under SUP-1059