### PR TITLE
Add EFAttachments directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN chmod 754 container-scripts/*.sh && \
     tar -xvf weblogic.tar && \
     cp -r weblogic/* ../chipsconfig && \
     rm ../chipsconfig/chips.ear && \
-    mkdir ../CloudImages
+    mkdir ../CloudImages && \
+    mkdir ../EFAttachments
 
 CMD ["bash"]


### PR DESCRIPTION
Add the EFAttachments directory to the image to hold transient pdf/pcl and tif images.  There will be a Docker volume mounted over this directory, but creating it first allows the permissions to be inherited so that it can be written into a by non-root user.

Resolves: https://companieshouse.atlassian.net/browse/CM-846
