### PR TITLE
Reference version 1.0.8 of chips-domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.7
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.8
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This brings in the chips-tuxedo-library jar to allow outgoing tuxedo calls to work while the CHIPS code is still being built against WL 12.1.3 but running under 12.2.1.4

Resolves: https://companieshouse.atlassian.net/browse/CM-940