### PR TITLE
Set chips-domain base image version to 1.0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.8
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.9
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
Version 1.0.9 of the chips-domain base image brings in the change to set the shrink frequency of the chipsDS connection pool to 300 secs.

Resolves: https://companieshouse.atlassian.net/browse/CM-1120