### PR TITLE
Reference 1.0.10 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.9
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.10
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
Reference a new version of the chips-domain base image to pull in the latest WebLogic patches

Resolves: https://companieshouse.atlassian.net/browse/CM-1157