### PR TITLE
Reference 1.0.12 of chips-domain for wladmin t3s channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.11
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.12
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This adds a new network channel to the wladmin server to allow access by t3 clients for monitoring and CSI tools.

Resolves: https://companieshouse.atlassian.net/browse/CM-1123
