### PR TITLE
Reference version 1.0.15 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.14
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.15
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This brings in the umask change for the WebLogic logs, that resolves an issue where the analytics services cannot read the WebLogic logs on the NFS due to permissions.