### PR TITLE
Reference 1.0.16 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.15
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.16
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
Reference a new version of chips-domain base image, to pull in an updated chips-fop-fonts package that has additional Times New Roman and Arial fonts to resolve a FOP rendering issue discovered on Live cloud CHIPS.

Resolves: https://companieshouse.atlassian.net/browse/CM-1423
