### PR TITLE
Reference version 1.0.17 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.16
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.17
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
Pulls in a new version of the chips-domain base image to include a patch that allows tuxedo connections to be resilient to ip address changes caused by EC2 instance refreshes.

Resolves: https://companieshouse.atlassian.net/browse/CM-1410