### PR TITLE
Reference version 1.0.18 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.17
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.18
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This brings in the config and code of the csi utility web app, that can be accessed with a context root of csi - i.e. /csi/log4jAdmin.jsp or /csi/setSysProp.jsp

Revolves: https://companieshouse.atlassian.net/browse/CM-1419
