### PR TITLE
Reference 1.0.21 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.18
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.21
 
 # Install gettext to provide envsubst
 USER root


### PR DESCRIPTION
This brings in an update to correct the ownership of the chipsdomain/upload folder to weblogic:weblogic

Revolves: https://companieshouse.atlassian.net/browse/CM-1419
