### PR TITLE
Use chips-domain:1.0.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.24
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.25
 
 USER root
 


### PR DESCRIPTION
Increment chips-domain version to pick up change for CM-1467 only retain 7 days of access logs