### PR TITLE
Reference 1.0.26 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.25
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.26
 
 USER root
 


### PR DESCRIPTION
Reference .0.26 of chips-domain base image to pull in fix to swadmin app for spurious 404 errors.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1472