### PR TITLE
Reference 1.0.27 of chips-domain base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.26
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.27
 
 USER root
 


### PR DESCRIPTION
This pulls in a new version of the swadmin tool 1.0.3 which has an increase 
in the number of work items displayed on a page.