### PR TITLE
Copy the notfound.tif to the chipsdomain directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ USER weblogic
 RUN chmod 754 container-scripts/*.sh && \
     cd ${DOMAIN_NAME}/upload && \
     tar -xvf weblogic.tar && \
+    mv weblogic/*.tif ../ && \
     cp -r weblogic/* ../chipsconfig && \
     rm ../chipsconfig/chips.ear && \
     mkdir ../CloudImages && \


### PR DESCRIPTION
The notfound.tif file (and the new suppressed.tif) were not being moved into the correct location as part of the deployment of the weblogic.tar during the build of the chips-app image.  This update moves *.tif to the chipsdomain folder.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1525