### PR TITLE
Optimise chips-app docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN cd ${DOMAIN_NAME}/upload && \
 
 FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.29
 
-USER weblogic 
-
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/chipsconfig ${DOMAIN_NAME}/chipsconfig/


### PR DESCRIPTION
Optimise the image size by using a multi-stage build.  This reduces the size from 2GB down to 1.7GB.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1526