### PR TITLE
Add folder creation for volumes back in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ COPY --chown=weblogic:weblogic container-scripts container-scripts/
 
 # Set permissions and move tif files into correct location
 RUN chmod 754 container-scripts/*.sh && \
+    mkdir ${DOMAIN_NAME}/CloudImages && \
+    mkdir ${DOMAIN_NAME}/EFAttachments && \
     mv ${DOMAIN_NAME}/upload/weblogic/*.tif ${DOMAIN_NAME}
 
 CMD ["bash"]


### PR DESCRIPTION
During testing, we have found that when the docker volumes are freshly created (e.g. after a termination of instance), the permissions are incorrect.  This was previously dealt with by creating the destination folders within the container in advance.

That folder creation was removed from the previous version of chips-app as it didn't seem to be needed any longer, but that was an error and so this PR reintroduces the folder creation.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1526