### PR TITLE
Update the chips-domain base image to 1.0.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.29 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.33 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.29
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.33
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Pull in the dev log4j config file and the app dynamics agent (disabled by default).

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1511 (Weblogic infrastructure for dev)
https://companieshouse.atlassian.net/browse/CM-1058 (app dynamics agent integration)