### PR TITLE
Reference chips-domain version 1.0.36 to improve JMS message viewing in console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.34 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.36 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.34
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.36
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
In order to view stuck FES (and other) JMS messages in the WebLogic console, the java classes the messages use must be present on the classpath. This change references a new version of chips-domain that includes more classes to enable viewing of Response and FES messages.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1548
