### PR TITLE
Reference version 1.0.37 of chips-domain to pull in new chca cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.36 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.37 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.36
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.37
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
The new cert is included in chips-domain 1.0.37. The new cert is needed as the previous cert is due to expire on 6th Aug.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1124
