### PR TITLE
Add ApplicationConfiguratorOverrides script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In order to use the image, a number of environment properties need to be defined
 |AD_GROUP_BASE_DN|The base location under which groups can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
 |AUTO_START_NODES|A list of managed server names to auto start when the container is launched|wlserver1,wlserver2,wlserver3,wlserver4
 |TZ|The timezone to use when running WebLogic|Europe/London
+|APPLICATION_CONFIGURATOR_OVERRIDE_#|Override a property in the ApplicationConfigurator.properties file.  E.g. APPLICATION_CONFIGURATOR_OVERRIDE_#="property=value". Multiple overrides can be used as long as each has a unique suffix (normally a number)|APPLICATION_CONFIGURATOR_OVERRIDE_1="staffware.ip.override.value=COBWEBUNIX2" 
 
 
 In addition to these properties which are required for the use of the Docker image, there are also a large number of existing environment properties that are needed to run the CHIPS application.  These are described in https://github.com/companieshouse/chips/blob/develop/ENVIRONMENT_PROPERTIES_README.md and are also listed in this repository https://github.com/companieshouse/chips-app/blob/main/chipsconfig/jms.properties.template

--- a/container-scripts/applicationConfiguratorOverrides.sh
+++ b/container-scripts/applicationConfiguratorOverrides.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script enumerates all environment variables named APPLICATION_CONFIGURATOR_OVERRIDE_*
+# and then adds the valus into an overrides file.  This allows specific properties to be overridden
+# on a per environment, or even per node, basis.
+# The variable names are of the form APPLICATION_CONFIGURATOR_OVERRIDE_#, where # is a suffix to 
+# ensure each variable has a unique name.  Normally this is just a number  - e.g. APPLICATION_CONFIGURATOR_OVERRIDE_1,
+# APPLICATION_CONFIGURATOR_OVERRIDE_2 etc
+
+
+DOMAIN_HOME="/apps/oracle/${DOMAIN_NAME}"
+OVERRIDES_FILE="${DOMAIN_HOME}/chipsconfig/ApplicationConfiguratorOverrides.properties"
+
+# Remove any existing overrides file
+rm -rf ${OVERRIDES_FILE}
+
+# Loop through all APPLICATION_CONFIGURATOR_OVERRIDE env vars and add to a new ApplicationConfiguratorOverrides.properties file
+OVERRIDES=$(env | sort | grep "^APPLICATION_CONFIGURATOR_OVERRIDE_")
+for OVERRIDE in ${OVERRIDES};
+do
+  echo ${OVERRIDE#*=} >> ${OVERRIDES_FILE}
+done

--- a/container-scripts/applyEnvAndStartNodeManagerAndManagedServer.sh
+++ b/container-scripts/applyEnvAndStartNodeManagerAndManagedServer.sh
@@ -4,5 +4,8 @@
 cd ~/${DOMAIN_NAME}/chipsconfig
 envsubst < jms.properties.template > jms.properties
 
+# Add ApplicationConfiguratorOverrides.properties file if required
+${ORACLE_HOME}/container-scripts/applicationConfiguratorOverrides.sh
+
 ~/container-scripts/startNodeManagerAndManagedServer.sh
 


### PR DESCRIPTION
Add a script that looks for `APPLICATION_CONFIGURATOR_OVERRIDE_#` environment variables and generates a 
`ApplicationConfiguratorOverrides.properties` file under `chipsdomain/chipsconfig`, which is used to override specific properties in the main `ApplicationConfigurator.properties` file in the same location.

This is intended to be used for the development environments, but can be used in production if the need arises.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1551