### PR TITLE
Reference 1.0.52 of chips-domain image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.51 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.52 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.51
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.52
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Reference 1.0.52 of chips-domain base image, to pull in removal of chips-tuxedo-library jar.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-14
