### PR TITLE
Bump version of chips-domain image to 1.0.53

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.52 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.53 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.52
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.53
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Pulls in the latest chips-domain image 1.0.53, to add the change that sets the jdbc client v$session.machine property so that instead of being just wlserver1, or wlserver2 etc, it is now waldorf-wlserver1 or waldorf-wlserver2 etc

This allows support teams to see where connections are being established from when monitoring the CHIPS databases.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-226
