### PR TITLE
Reference chips-domain 1.0.54 for complete-message-timeout change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.53 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.54 as builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.53
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.54
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Reference a new version of the chips-domain image (1.0.54) to pull in a change that increases the `complete-message-timeout` to 300 seconds.

This allows downloads of large zips in query handling, over a slower connection such as via VPN. Without the increased timeout, the downloads are getting cancelled by Weblogic if they take more 60 seconds.

Resolves:
https://companieshouse.atlassian.net/browse/AOAF-556
