### PR TITLE
Reference 1.0.56 of chips-domain for PDFBox fonts issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.54 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.56 AS builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.54
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.56
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Brings in a newer chips-domain image (1.0.56) that contains a link to existing fonts so that they can be found by PDFBox.

Also brings in a fix, contained within chips-domain, for viewing JMS messages via the Weblogic admin console that was made by CSI.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-274