### PR TITLE
Update chips-domain to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.56 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.57 AS builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.56
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.57
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Refer to latest version of chips-domain that includes the java classes for the new ACSP JMS messages

See https://github.com/companieshouse/chips-domain/pull/50 