### PR TITLE
Remove Email, Jaffware, Insolvency, Cedar and Print related JMS queues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.57 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.59 AS builder
 
 USER root
 
@@ -17,7 +17,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.57
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0.59
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/

--- a/chipsconfig/jms.properties.template
+++ b/chipsconfig/jms.properties.template
@@ -8,12 +8,10 @@ jms.queueConnectionFactoryName=${JMS_QUEUECONNECTIONFACTORYNAME}
 # Queue names
 #
 jms.staffwareQueue=${JMS_STAFFWAREQUEUE}
-jms.cedarQueue=${JMS_CEDARQUEUE}
 jms.officerEventQueue=${JMS_OFFICEREVENTQUEUE}
 jms.transactionListenerQueue=${JMS_TRANSACTIONLISTENERQUEUE}
 jms.efilingImageQueue=${JMS_EFILINGIMAGEQUEUE}
 jms.efilingShareholdingsQueue=${JMS_EFILINGSHAREHOLDINGSQUEUE}
-jms.printQueue=${JMS_PRINTQUEUE}
 jms.dissolutionCertificatesProducerQueue=${JMS_DISSOLUTIONCERTIFICATESPRODUCERQUEUE}
 jms.fesQueue=${JMS_FESQUEUE}
 jms.imageApiQueue=${JMS_IMAGEAPIQUEUE}


### PR DESCRIPTION
The MDBs for the following queues have been removed recently, so this is a follow-up change to remove the JMS queue config for these queues:

    EmailQueue & EmailErrorQueue
    JaffwareQueue & JaffwareErrorQueue
    InsolvencyPursuitQueue & InsolvencyPursuitErrorQueue
    CedarQueue & CedarErrorQueue
    PrintQueue

Resolves:
https://companieshouse.atlassian.net/browse/CHP-410
