### PR TITLE
Update env var to use proper convention

### DIFF
--- a/chipsconfig/jms.properties.template
+++ b/chipsconfig/jms.properties.template
@@ -261,5 +261,5 @@ feature.flag.ixbrl.suppression=${FEATURE_FLAG_IXBRL_SUPPRESSION}
 # Allow list for on behalf of service users
 onbehalfof.allowed.users=${ONBEHALFOF_ALLOWED_USERS}
 
-chs.notification.api.base.url=${CHS_NOTIFICATION_SENDER_API_URL}
-chs.notification.api.auth.key=${CHS_NOTIFICATION_SENDER_API_KEY}
+chs.notification.api.base.url=${CHS_NOTIFICATION_API_BASE_URL}
+chs.notification.api.auth.key=${CHS_NOTIFICATION_API_AUTH_KEY}


### PR DESCRIPTION
As per https://companieshouse.atlassian.net/wiki/spaces/CSI/pages/4196368635/API+Key+Rotation#AWS-Parameter-Store---Parameter-Name-Convention -  I've updated to be more clear/consistent env var names.

- `CHS_NOTIFICATION_SENDER_API_URL` -> https://github.com/companieshouse/chs-notification-sender-api 
- `CHS_NOTIFICATION_SENDER_API_KEY`