### PR TITLE
Reference 2.0.14 of chips-domain for log4j2 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.13 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.14 AS builder
+
 
 USER root
 
@@ -17,7 +18,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.13
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.14
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.14 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.15 AS builder
 
 
 USER root
@@ -18,7 +18,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.14
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.15
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Updates the log4j dependencies and classpath so that log4j2 and log4j to log4j2 bridge is used.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1070

(shouldn't be merged to main until just before cutoff of the release it is targeting)