### PR TITLE
Reference chips-domain 2.0.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.15 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.17 AS builder
 
 
 USER root
@@ -18,7 +18,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.15
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.17
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Reference chips-domain 2.0.17 to pull in config change to disable the auth cookie, for CHP-1221.
Also pulls in a log4j config change that updates some classnames due to the MDB -> listener conversion work, for CHP-1232.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-1221 (auth cookie change)
https://companieshouse.atlassian.net/browse/CHP-1232 (log4j config class names update)