### PR TITLE
Reference 2.0.18 of chips-domain for updated swadmin app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.17 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.18 AS builder
 
 
 USER root
@@ -18,7 +18,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
     rm ../chipsconfig/chips.ear && \
     rm weblogic.tar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.17
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:2.0.18
 
 # Copy over upload and chipsconfig
 COPY --from=builder --chown=weblogic:weblogic /apps/oracle/${DOMAIN_NAME}/upload ${DOMAIN_NAME}/upload/


### PR DESCRIPTION
Update the version of the base chips-domain image to 2.0.18 to pull in an updated 2.0.0 version of the swadmin app, which has been built with Java 21/WL14 libs and uses log4j2.

https://companieshouse.atlassian.net/browse/CHP-1209